### PR TITLE
Support repository and snapshot with Google GCS using S3 repository plugin.

### DIFF
--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/AmazonAsyncS3Reference.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/AmazonAsyncS3Reference.java
@@ -45,4 +45,8 @@ public class AmazonAsyncS3Reference extends RefCountedReleasable<AmazonAsyncS3Wi
     public void setFullyS3Compatible(boolean fullyS3Compatible) {
         this.fullyS3Compatible = fullyS3Compatible;
     }
+
+    public boolean isFullyS3Compatible() {
+        return fullyS3Compatible;
+    }
 }

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/AmazonAsyncS3Reference.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/AmazonAsyncS3Reference.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 public class AmazonAsyncS3Reference extends RefCountedReleasable<AmazonAsyncS3WithCredentials> {
 
     private static final Logger logger = LogManager.getLogger(AmazonAsyncS3Reference.class);
+    boolean fullyS3Compatible = true;
 
     AmazonAsyncS3Reference(AmazonAsyncS3WithCredentials client) {
         super("AWS_S3_CLIENT", client, () -> {
@@ -39,5 +40,9 @@ public class AmazonAsyncS3Reference extends RefCountedReleasable<AmazonAsyncS3Wi
                 }
             }
         });
+    }
+
+    public void setFullyS3Compatible(boolean fullyS3Compatible) {
+        this.fullyS3Compatible = fullyS3Compatible;
     }
 }

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/AmazonS3Reference.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/AmazonS3Reference.java
@@ -43,6 +43,8 @@ import org.opensearch.common.concurrent.RefCountedReleasable;
  * counting.
  */
 public class AmazonS3Reference extends RefCountedReleasable<S3Client> {
+    boolean fullyS3Compatible = true;
+
     AmazonS3Reference(S3Client client) {
         this(client, null);
     }
@@ -63,4 +65,9 @@ public class AmazonS3Reference extends RefCountedReleasable<S3Client> {
             }
         });
     }
+
+    public void setFullyS3Compatible(boolean fullyS3Compatible) {
+        this.fullyS3Compatible = fullyS3Compatible;
+    }
+
 }

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/AmazonS3Reference.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/AmazonS3Reference.java
@@ -70,4 +70,8 @@ public class AmazonS3Reference extends RefCountedReleasable<S3Client> {
         this.fullyS3Compatible = fullyS3Compatible;
     }
 
+    public boolean isFullyS3Compatible() {
+        return fullyS3Compatible;
+    }
+
 }

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/NoneBatchableDeleteHelper.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/NoneBatchableDeleteHelper.java
@@ -1,0 +1,269 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+package org.opensearch.repositories.s3;
+
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class NoneBatchableDeleteHelper {
+    public static int MAX_DELETE_THREADS = 50;
+
+    public static class DefaultThreadFactory implements ThreadFactory {
+
+        private static final AtomicInteger poolNumber = new AtomicInteger(1);
+        private final ThreadGroup group;
+        private final AtomicInteger threadNumber = new AtomicInteger(1);
+        private final String namePrefix;
+
+        public DefaultThreadFactory() {
+            this("pool-" + poolNumber.getAndIncrement() + "-thread-");
+        }
+
+        public DefaultThreadFactory(String namePrefix) {
+            SecurityManager s = System.getSecurityManager();
+            group = (s != null) ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();
+            this.namePrefix = namePrefix;
+        }
+
+        @Override
+        public Thread newThread(Runnable r) {
+            Thread t = new Thread(group, r, namePrefix + threadNumber.getAndIncrement(), 0);
+            if (t.isDaemon()) t.setDaemon(false);
+            if (t.getPriority() != Thread.NORM_PRIORITY) t.setPriority(Thread.NORM_PRIORITY);
+            return t;
+        }
+
+    }
+
+    /**
+     * Deletes objects from the S3 bucket using the provided S3AsyncClient and an iterator of ListObjectsV2Response.
+     * @param s3AsyncClient
+     * @param bucketName
+     * @param listObjectsResponseIterator
+     * @throws SdkException
+     */
+    public static void deleteObjectsFromListObjectResultIgnoreNotExists(
+        S3AsyncClient s3AsyncClient,
+        String bucketName,
+        Iterator<ListObjectsV2Response> listObjectsResponseIterator
+    ) throws SdkException {
+
+        DefaultThreadFactory threadFactory = new DefaultThreadFactory("s3-delete-objects-");
+        final ExecutorService deleteTaskPool = Executors.newFixedThreadPool(MAX_DELETE_THREADS, threadFactory);
+
+        try {
+            while (listObjectsResponseIterator.hasNext()) {
+                ListObjectsV2Response listObjectsResponse = SocketAccess.doPrivileged(listObjectsResponseIterator::next);
+                if (listObjectsResponse.hasContents()) {
+                    listObjectsResponse.contents().forEach(s3Object -> {
+                        deleteTaskPool.execute(() -> {
+                            try {
+                                s3AsyncClient.deleteObject(DeleteObjectRequest.builder().bucket(bucketName).key(s3Object.key()).build())
+                                    .get();
+                            } catch (Exception e) {
+                                // Do nothing
+                            }
+                        });
+                    });
+                }
+            }
+        } finally {
+            try {
+                if (deleteTaskPool != null) {
+                    deleteTaskPool.shutdown();
+                    try {
+                        deleteTaskPool.awaitTermination(60, TimeUnit.MINUTES);
+                    } catch (Exception e) {}
+                }
+            } finally {
+                if (deleteTaskPool != null) {
+                    deleteTaskPool.shutdownNow();
+                }
+            }
+        }
+    }
+
+    /**
+     * Deletes objects from the S3 bucket using the provided S3AsyncClient and a list of object keys.
+     * @param s3Client
+     * @param bucketName
+     * @param listObjects
+     * @return Set of object keys that were not found or not deleted.
+     * @throws SdkException
+     */
+    public static Set<String> deleteObjectsIgnoreNotExists(
+        S3Client s3Client,
+        String bucketName,
+        List<String> listObjects,
+        Set<String> outstanding
+    ) throws SdkException {
+
+        DefaultThreadFactory threadFactory = new DefaultThreadFactory("s3-delete-objects-");
+        final ExecutorService deleteTaskPool = Executors.newFixedThreadPool(MAX_DELETE_THREADS, threadFactory);
+        Set<String> synchedOutstanding = Collections.synchronizedSet(outstanding);
+
+        try {
+            for (String objectKey : listObjects) {
+                deleteTaskPool.execute(() -> {
+                    try {
+                        SocketAccess.doPrivilegedVoid(
+                            () -> { s3Client.deleteObject(DeleteObjectRequest.builder().bucket(bucketName).key(objectKey).build()); }
+                        );
+                        synchedOutstanding.remove(objectKey);
+                    } catch (S3Exception e) {
+                        if ("NoSuchKey".equalsIgnoreCase(e.awsErrorDetails().errorCode())) {
+                            synchedOutstanding.remove(objectKey);
+                        }
+                        // Else, do nothing, just keep the key as outstanding.
+                    } catch (Exception e) {
+                        String errorMessage = e.getMessage();
+                        // Do nothing, just keep the key as outstanding.
+                    }
+                });
+            }
+        } finally {
+            try {
+                if (deleteTaskPool != null) {
+                    deleteTaskPool.shutdown();
+                    try {
+                        deleteTaskPool.awaitTermination(60, TimeUnit.MINUTES);
+                    } catch (Exception e) {}
+                }
+            } finally {
+                if (deleteTaskPool != null) {
+                    deleteTaskPool.shutdownNow();
+                }
+            }
+        }
+        return synchedOutstanding;
+    }
+
+    /**
+     * Deletes objects from the S3 bucket using the provided S3AsyncClient and an iterator of ListObjectsV2Response.
+     * @param s3Client
+     * @param bucketName
+     * @param listObjectsResponseIterator
+     * @throws SdkException
+     */
+    public static void deleteObjectsFromListObjectResultIgnoreNotExists(
+        S3Client s3Client,
+        String bucketName,
+        Iterator<ListObjectsV2Response> listObjectsResponseIterator
+    ) throws SdkException {
+
+        DefaultThreadFactory threadFactory = new DefaultThreadFactory("s3-delete-objects-");
+        final ExecutorService deleteTaskPool = Executors.newFixedThreadPool(MAX_DELETE_THREADS, threadFactory);
+
+        try {
+            while (listObjectsResponseIterator.hasNext()) {
+                ListObjectsV2Response listObjectsResponse = SocketAccess.doPrivileged(listObjectsResponseIterator::next);
+                if (listObjectsResponse.hasContents()) {
+                    listObjectsResponse.contents().forEach(s3Object -> {
+                        deleteTaskPool.execute(() -> {
+                            try {
+                                s3Client.deleteObject(DeleteObjectRequest.builder().bucket(bucketName).key(s3Object.key()).build());
+                            } catch (Exception e) {
+                                // Do nothing
+                            }
+                        });
+                    });
+                }
+            }
+        } finally {
+            try {
+                if (deleteTaskPool != null) {
+                    deleteTaskPool.shutdown();
+                    try {
+                        deleteTaskPool.awaitTermination(60, TimeUnit.MINUTES);
+                    } catch (Exception e) {}
+                }
+            } finally {
+                if (deleteTaskPool != null) {
+                    deleteTaskPool.shutdownNow();
+                }
+            }
+        }
+    }
+
+    /**
+     * Deletes objects from the S3 bucket using the provided S3AsyncClient and a list of object keys.
+     * @param s3AsyncClient
+     * @param bucketName
+     * @param listObjects
+     * @throws SdkException
+     */
+    public static void deleteObjectsIgnoreNotExists(S3AsyncClient s3AsyncClient, String bucketName, List<String> listObjects)
+        throws SdkException {
+
+        DefaultThreadFactory threadFactory = new DefaultThreadFactory("s3-delete-objects-");
+        final ExecutorService deleteTaskPool = Executors.newFixedThreadPool(MAX_DELETE_THREADS, threadFactory);
+
+        try {
+            for (String objectKey : listObjects) {
+                deleteTaskPool.execute(() -> {
+                    try {
+                        s3AsyncClient.deleteObject(DeleteObjectRequest.builder().bucket(bucketName).key(objectKey).build()).get();
+                    } catch (Exception e) {
+                        // Do nothing
+                    }
+                });
+            }
+        } finally {
+            try {
+                if (deleteTaskPool != null) {
+                    deleteTaskPool.shutdown();
+                    try {
+                        deleteTaskPool.awaitTermination(60, TimeUnit.MINUTES);
+                    } catch (Exception e) {}
+                }
+            } finally {
+                if (deleteTaskPool != null) {
+                    deleteTaskPool.shutdownNow();
+                }
+            }
+        }
+    }
+}

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3AsyncService.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3AsyncService.java
@@ -124,6 +124,12 @@ class S3AsyncService implements Closeable {
             final AmazonAsyncS3Reference clientReference = new AmazonAsyncS3Reference(
                 buildClient(clientSettings, urgentExecutorBuilder, priorityExecutorBuilder, normalExecutorBuilder)
             );
+            String endpoint = clientSettings.endpoint;
+            if (endpoint != null) {
+                if (endpoint.toLowerCase().contains("storage.googleapis.com")) {
+                    clientReference.setFullyS3Compatible(false);
+                }
+            }
             clientReference.incRef();
             clientsCache = MapBuilder.newMapBuilder(clientsCache).put(clientSettings, clientReference).immutableMap();
             return clientReference;

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3AsyncService.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3AsyncService.java
@@ -126,7 +126,7 @@ class S3AsyncService implements Closeable {
             );
             String endpoint = clientSettings.endpoint;
             if (endpoint != null) {
-                if (endpoint.toLowerCase().contains("storage.googleapis.com")) {
+                if (endpoint.contains("storage.googleapis.com")) {
                     clientReference.setFullyS3Compatible(false);
                 }
             }

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3AsyncService.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3AsyncService.java
@@ -34,6 +34,7 @@ import software.amazon.awssdk.services.sts.StsClientBuilder;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
 import software.amazon.awssdk.services.sts.auth.StsWebIdentityTokenFileCredentialsProvider;
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+import software.amazon.awssdk.utils.AttributeMap;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -46,7 +47,6 @@ import org.opensearch.core.common.Strings;
 import org.opensearch.repositories.s3.S3ClientSettings.IrsaCredentials;
 import org.opensearch.repositories.s3.async.AsyncExecutorContainer;
 import org.opensearch.repositories.s3.async.AsyncTransferEventLoopGroup;
-import software.amazon.awssdk.utils.AttributeMap;
 
 import java.io.Closeable;
 import java.io.IOException;

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3BlobContainer.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3BlobContainer.java
@@ -924,6 +924,7 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
     public void deleteAsync(ActionListener<DeleteResult> completionListener) {
         try (AmazonAsyncS3Reference asyncClientReference = blobStore.asyncClientReference()) {
             S3AsyncClient s3AsyncClient = asyncClientReference.get().client();
+            final boolean isFullyS3Compatible = asyncClientReference.isFullyS3Compatible();
 
             ListObjectsV2Request listRequest = ListObjectsV2Request.builder().bucket(blobStore.bucket()).prefix(keyPath).build();
             ListObjectsV2Publisher listPublisher = s3AsyncClient.listObjectsV2Paginator(listRequest);
@@ -952,23 +953,28 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
                         objectsToDelete.add(s3Object.key());
                     });
 
-                    int bulkDeleteSize = blobStore.getBulkDeletesSize();
-                    if (objectsToDelete.size() >= bulkDeleteSize) {
-                        int fullBatchesCount = objectsToDelete.size() / bulkDeleteSize;
-                        int itemsToDelete = fullBatchesCount * bulkDeleteSize;
+                    if (isFullyS3Compatible) {
+                        int bulkDeleteSize = blobStore.getBulkDeletesSize();
+                        if (objectsToDelete.size() >= bulkDeleteSize) {
+                            int fullBatchesCount = objectsToDelete.size() / bulkDeleteSize;
+                            int itemsToDelete = fullBatchesCount * bulkDeleteSize;
 
-                        List<String> batchToDelete = new ArrayList<>(objectsToDelete.subList(0, itemsToDelete));
-                        objectsToDelete.subList(0, itemsToDelete).clear();
+                            List<String> batchToDelete = new ArrayList<>(objectsToDelete.subList(0, itemsToDelete));
+                            objectsToDelete.subList(0, itemsToDelete).clear();
 
-                        deletionChain = S3AsyncDeleteHelper.executeDeleteChain(
-                            s3AsyncClient,
-                            blobStore,
-                            batchToDelete,
-                            deletionChain,
-                            () -> subscription.request(1)
-                        );
+                            deletionChain = S3AsyncDeleteHelper.executeDeleteChain(
+                                s3AsyncClient,
+                                blobStore,
+                                batchToDelete,
+                                deletionChain,
+                                () -> subscription.request(1)
+                            );
+                        } else {
+                            subscription.request(1);
+                        }
                     } else {
-                        subscription.request(1);
+                        // Google does not support bulk deletes, so we delete each blob individually using multiple threads.
+                        NoneBatchableDeleteHelper.deleteObjectsIgnoreNotExists(s3AsyncClient, blobStore.bucket(), objectsToDelete);
                     }
                 }
 
@@ -1025,15 +1031,24 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
             S3AsyncClient s3AsyncClient = asyncClientReference.get().client();
 
             List<String> keysToDelete = blobNames.stream().map(this::buildKey).collect(Collectors.toList());
-
-            S3AsyncDeleteHelper.executeDeleteChain(s3AsyncClient, blobStore, keysToDelete, CompletableFuture.completedFuture(null), null)
-                .whenComplete((v, throwable) -> {
+            if (asyncClientReference.isFullyS3Compatible()) {
+                S3AsyncDeleteHelper.executeDeleteChain(
+                    s3AsyncClient,
+                    blobStore,
+                    keysToDelete,
+                    CompletableFuture.completedFuture(null),
+                    null
+                ).whenComplete((v, throwable) -> {
                     if (throwable != null) {
                         completionListener.onFailure(new IOException("Failed to delete blobs " + blobNames, throwable));
                     } else {
                         completionListener.onResponse(null);
                     }
                 });
+            } else {
+                // Google does not support bulk deletes, so we delete each blob individually using multiple threads.
+                NoneBatchableDeleteHelper.deleteObjectsIgnoreNotExists(s3AsyncClient, blobStore.bucket(), keysToDelete);
+            }
         } catch (Exception e) {
             completionListener.onFailure(new IOException("Failed to initiate async blob deletion", e));
         }

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3BlobContainer.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3BlobContainer.java
@@ -385,18 +385,31 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
         final AtomicLong deletedBlobs = new AtomicLong();
         final AtomicLong deletedBytes = new AtomicLong();
         try (AmazonS3Reference clientReference = blobStore.clientReference()) {
-            ListObjectsV2Iterable listObjectsIterable = SocketAccess.doPrivileged(
-                () -> clientReference.get()
-                    .listObjectsV2Paginator(
-                        ListObjectsV2Request.builder()
-                            .bucket(blobStore.bucket())
-                            .prefix(keyPath)
-                            .overrideConfiguration(
-                                o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().listObjectsMetricPublisher)
-                            )
-                            .build()
-                    )
-            );
+            ListObjectsV2Iterable listObjectsIterable;
+            if (clientReference.isFullyS3Compatible()) {
+                listObjectsIterable = SocketAccess.doPrivileged(
+                    () -> clientReference.get()
+                        .listObjectsV2Paginator(
+                            ListObjectsV2Request.builder()
+                                .bucket(blobStore.bucket())
+                                .prefix(keyPath)
+                                .overrideConfiguration(
+                                    o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().listObjectsMetricPublisher)
+                                )
+                                .build()
+                        )
+                );
+            } else {
+                listObjectsIterable = SocketAccess.doPrivileged(
+                    () -> clientReference.get()
+                        .listObjectsV2Paginator(
+                            ListObjectsV2Request.builder()
+                                .bucket(blobStore.bucket())
+                                .prefix(keyPath)
+                                .build()
+                        )
+                );
+            }
 
             Iterator<ListObjectsV2Response> listObjectsResponseIterator = listObjectsIterable.iterator();
             while (listObjectsResponseIterator.hasNext()) {
@@ -516,7 +529,7 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
             }
             String prefix = blobNamePrefix == null ? keyPath : buildKey(blobNamePrefix);
             try (AmazonS3Reference clientReference = blobStore.clientReference()) {
-                List<BlobMetadata> blobs = executeListing(clientReference, listObjectsRequest(prefix, limit), limit).stream()
+                List<BlobMetadata> blobs = executeListing(clientReference, listObjectsRequest(prefix, limit, clientReference.isFullyS3Compatible()), limit).stream()
                     .flatMap(listing -> listing.contents().stream())
                     .map(s3Object -> new PlainBlobMetadata(s3Object.key().substring(keyPath.length()), s3Object.size()))
                     .collect(Collectors.toList());
@@ -531,7 +544,7 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
     public Map<String, BlobMetadata> listBlobsByPrefix(@Nullable String blobNamePrefix) throws IOException {
         String prefix = blobNamePrefix == null ? keyPath : buildKey(blobNamePrefix);
         try (AmazonS3Reference clientReference = blobStore.clientReference()) {
-            return executeListing(clientReference, listObjectsRequest(prefix)).stream()
+            return executeListing(clientReference, listObjectsRequest(prefix, clientReference.isFullyS3Compatible())).stream()
                 .flatMap(listing -> listing.contents().stream())
                 .map(s3Object -> new PlainBlobMetadata(s3Object.key().substring(keyPath.length()), s3Object.size()))
                 .collect(Collectors.toMap(PlainBlobMetadata::name, Function.identity()));
@@ -548,7 +561,7 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
     @Override
     public Map<String, BlobContainer> children() throws IOException {
         try (AmazonS3Reference clientReference = blobStore.clientReference()) {
-            return executeListing(clientReference, listObjectsRequest(keyPath)).stream().flatMap(listObjectsResponse -> {
+            return executeListing(clientReference, listObjectsRequest(keyPath, clientReference.isFullyS3Compatible())).stream().flatMap(listObjectsResponse -> {
                 assert listObjectsResponse.contents().stream().noneMatch(s -> {
                     for (CommonPrefix commonPrefix : listObjectsResponse.commonPrefixes()) {
                         if (s.key().substring(keyPath.length()).startsWith(commonPrefix.prefix())) {
@@ -593,17 +606,19 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
         });
     }
 
-    private ListObjectsV2Request listObjectsRequest(String keyPath) {
-        return ListObjectsV2Request.builder()
+    private ListObjectsV2Request listObjectsRequest(String keyPath, boolean isFullyS3Compatible) {
+        ListObjectsV2Request.Builder listObjectsV2RequestBuilder = ListObjectsV2Request.builder()
             .bucket(blobStore.bucket())
             .prefix(keyPath)
-            .delimiter("/")
-            .overrideConfiguration(o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().listObjectsMetricPublisher))
-            .build();
+            .delimiter("/");
+        if (isFullyS3Compatible) {
+            listObjectsV2RequestBuilder.overrideConfiguration(o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().listObjectsMetricPublisher));
+        }
+        return listObjectsV2RequestBuilder.build();
     }
 
-    private ListObjectsV2Request listObjectsRequest(String keyPath, int limit) {
-        return listObjectsRequest(keyPath).toBuilder().maxKeys(Math.min(limit, 1000)).build();
+    private ListObjectsV2Request listObjectsRequest(String keyPath, int limit, boolean isFullyS3Compatible) {
+        return listObjectsRequest(keyPath, isFullyS3Compatible).toBuilder().maxKeys(Math.min(limit, 1000)).build();
     }
 
     private String buildKey(String blobName) {
@@ -633,9 +648,7 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
             .bucket(blobStore.bucket())
             .key(blobName)
             .contentLength(blobSize)
-            .storageClass(blobStore.getStorageClass())
-            .acl(blobStore.getCannedACL())
-            .overrideConfiguration(o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().putObjectMetricPublisher));
+            .storageClass(blobStore.getStorageClass());
 
         if (CollectionUtils.isNotEmpty(metadata)) {
             putObjectRequestBuilder = putObjectRequestBuilder.metadata(metadata);
@@ -644,8 +657,15 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
             putObjectRequestBuilder.serverSideEncryption(ServerSideEncryption.AES256);
         }
 
-        PutObjectRequest putObjectRequest = putObjectRequestBuilder.build();
         try (AmazonS3Reference clientReference = blobStore.clientReference()) {
+
+            if (clientReference.isFullyS3Compatible()) {
+                putObjectRequestBuilder
+                    .acl(blobStore.getCannedACL())
+                    .overrideConfiguration(o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().putObjectMetricPublisher));
+            }
+            PutObjectRequest putObjectRequest = putObjectRequestBuilder.build();
+
             final InputStream requestInputStream;
             if (blobStore.isUploadRetryEnabled()) {
                 requestInputStream = new BufferedInputStream(input, (int) (blobSize + 1));
@@ -690,9 +710,7 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
         CreateMultipartUploadRequest.Builder createMultipartUploadRequestBuilder = CreateMultipartUploadRequest.builder()
             .bucket(bucketName)
             .key(blobName)
-            .storageClass(blobStore.getStorageClass())
-            .acl(blobStore.getCannedACL())
-            .overrideConfiguration(o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().multipartUploadMetricCollector));
+            .storageClass(blobStore.getStorageClass());
 
         if (CollectionUtils.isNotEmpty(metadata)) {
             createMultipartUploadRequestBuilder.metadata(metadata);
@@ -709,8 +727,15 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
             requestInputStream = input;
         }
 
-        CreateMultipartUploadRequest createMultipartUploadRequest = createMultipartUploadRequestBuilder.build();
         try (AmazonS3Reference clientReference = blobStore.clientReference()) {
+
+            if (clientReference.isFullyS3Compatible()) {
+                createMultipartUploadRequestBuilder
+                    .acl(blobStore.getCannedACL())
+                    .overrideConfiguration(o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().multipartUploadMetricCollector));
+            }
+            CreateMultipartUploadRequest createMultipartUploadRequest = createMultipartUploadRequestBuilder.build();
+
             uploadId.set(
                 SocketAccess.doPrivileged(() -> clientReference.get().createMultipartUpload(createMultipartUploadRequest).uploadId())
             );
@@ -722,14 +747,17 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
 
             long bytesCount = 0;
             for (int i = 1; i <= nbParts; i++) {
-                final UploadPartRequest uploadPartRequest = UploadPartRequest.builder()
-                    .bucket(bucketName)
-                    .key(blobName)
-                    .uploadId(uploadId.get())
-                    .partNumber(i)
-                    .contentLength((i < nbParts) ? partSize : lastPartSize)
-                    .overrideConfiguration(o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().multipartUploadMetricCollector))
-                    .build();
+                UploadPartRequest.Builder uploadPartRequestBuilder = UploadPartRequest.builder()
+                        .bucket(bucketName)
+                        .key(blobName)
+                        .uploadId(uploadId.get())
+                        .partNumber(i)
+                        .contentLength((i < nbParts) ? partSize : lastPartSize);
+                if (clientReference.isFullyS3Compatible()) {
+                    uploadPartRequestBuilder
+                        .overrideConfiguration(o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().multipartUploadMetricCollector));
+                }
+                final UploadPartRequest uploadPartRequest = uploadPartRequestBuilder.build();
 
                 bytesCount += uploadPartRequest.contentLength();
                 final UploadPartResponse uploadResponse = SocketAccess.doPrivileged(
@@ -745,13 +773,17 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
                 );
             }
 
-            CompleteMultipartUploadRequest completeMultipartUploadRequest = CompleteMultipartUploadRequest.builder()
+            CompleteMultipartUploadRequest.Builder multipartUploadRequestBuilder = CompleteMultipartUploadRequest.builder()
                 .bucket(bucketName)
                 .key(blobName)
                 .uploadId(uploadId.get())
-                .multipartUpload(CompletedMultipartUpload.builder().parts(parts).build())
-                .overrideConfiguration(o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().multipartUploadMetricCollector))
-                .build();
+                .multipartUpload(CompletedMultipartUpload.builder().parts(parts).build());
+            if (clientReference.isFullyS3Compatible()) {
+                multipartUploadRequestBuilder
+                    .overrideConfiguration(o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().multipartUploadMetricCollector));
+            }
+
+            CompleteMultipartUploadRequest completeMultipartUploadRequest = multipartUploadRequestBuilder.build();
 
             SocketAccess.doPrivilegedVoid(() -> clientReference.get().completeMultipartUpload(completeMultipartUploadRequest));
             success = true;

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3BlobContainer.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3BlobContainer.java
@@ -402,12 +402,7 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
             } else {
                 listObjectsIterable = SocketAccess.doPrivileged(
                     () -> clientReference.get()
-                        .listObjectsV2Paginator(
-                            ListObjectsV2Request.builder()
-                                .bucket(blobStore.bucket())
-                                .prefix(keyPath)
-                                .build()
-                        )
+                        .listObjectsV2Paginator(ListObjectsV2Request.builder().bucket(blobStore.bucket()).prefix(keyPath).build())
                 );
             }
 
@@ -450,52 +445,57 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
             outstanding = new HashSet<>(blobNames);
         }
         try (AmazonS3Reference clientReference = blobStore.clientReference()) {
-            // S3 API allows 1k blobs per delete so we split up the given blobs into requests of bulk size deletes
-            final List<DeleteObjectsRequest> deleteRequests = new ArrayList<>();
-            final List<String> partition = new ArrayList<>();
-            for (String key : outstanding) {
-                partition.add(key);
-                if (partition.size() == blobStore.getBulkDeletesSize()) {
-                    deleteRequests.add(bulkDelete(blobStore.bucket(), partition));
-                    partition.clear();
-                }
-            }
-            if (partition.isEmpty() == false) {
-                deleteRequests.add(bulkDelete(blobStore.bucket(), partition));
-            }
-            SocketAccess.doPrivilegedVoid(() -> {
-                SdkException aex = null;
-                for (DeleteObjectsRequest deleteRequest : deleteRequests) {
-                    List<String> keysInRequest = deleteRequest.delete()
-                        .objects()
-                        .stream()
-                        .map(ObjectIdentifier::key)
-                        .collect(Collectors.toList());
-                    try {
-                        DeleteObjectsResponse deleteObjectsResponse = clientReference.get().deleteObjects(deleteRequest);
-                        outstanding.removeAll(keysInRequest);
-                        outstanding.addAll(deleteObjectsResponse.errors().stream().map(S3Error::key).collect(Collectors.toSet()));
-                        if (!deleteObjectsResponse.errors().isEmpty()) {
-                            logger.warn(
-                                () -> new ParameterizedMessage(
-                                    "Failed to delete some blobs {}",
-                                    deleteObjectsResponse.errors()
-                                        .stream()
-                                        .map(s3Error -> "[" + s3Error.key() + "][" + s3Error.code() + "][" + s3Error.message() + "]")
-                                        .collect(Collectors.toList())
-                                )
-                            );
-                        }
-                    } catch (SdkException e) {
-                        // The AWS client threw any unexpected exception and did not execute the request at all so we do not
-                        // remove any keys from the outstanding deletes set.
-                        aex = ExceptionsHelper.useOrSuppress(aex, e);
+            if (clientReference.isFullyS3Compatible()) {
+                // S3 API allows 1k blobs per delete so we split up the given blobs into requests of bulk size deletes
+                final List<DeleteObjectsRequest> deleteRequests = new ArrayList<>();
+                final List<String> partition = new ArrayList<>();
+                for (String key : outstanding) {
+                    partition.add(key);
+                    if (partition.size() == blobStore.getBulkDeletesSize()) {
+                        deleteRequests.add(bulkDelete(blobStore.bucket(), partition));
+                        partition.clear();
                     }
                 }
-                if (aex != null) {
-                    throw aex;
+                if (partition.isEmpty() == false) {
+                    deleteRequests.add(bulkDelete(blobStore.bucket(), partition));
                 }
-            });
+                SocketAccess.doPrivilegedVoid(() -> {
+                    SdkException aex = null;
+                    for (DeleteObjectsRequest deleteRequest : deleteRequests) {
+                        List<String> keysInRequest = deleteRequest.delete()
+                            .objects()
+                            .stream()
+                            .map(ObjectIdentifier::key)
+                            .collect(Collectors.toList());
+                        try {
+                            DeleteObjectsResponse deleteObjectsResponse = clientReference.get().deleteObjects(deleteRequest);
+                            outstanding.removeAll(keysInRequest);
+                            outstanding.addAll(deleteObjectsResponse.errors().stream().map(S3Error::key).collect(Collectors.toSet()));
+                            if (!deleteObjectsResponse.errors().isEmpty()) {
+                                logger.warn(
+                                    () -> new ParameterizedMessage(
+                                        "Failed to delete some blobs {}",
+                                        deleteObjectsResponse.errors()
+                                            .stream()
+                                            .map(s3Error -> "[" + s3Error.key() + "][" + s3Error.code() + "][" + s3Error.message() + "]")
+                                            .collect(Collectors.toList())
+                                    )
+                                );
+                            }
+                        } catch (SdkException e) {
+                            // The AWS client threw any unexpected exception and did not execute the request at all so we do not
+                            // remove any keys from the outstanding deletes set.
+                            aex = ExceptionsHelper.useOrSuppress(aex, e);
+                        }
+                    }
+                    if (aex != null) {
+                        throw aex;
+                    }
+                });
+            } else {
+                // Google does not support bulk deletes, so we delete each blob individually using multiple threads.
+                NoneBatchableDeleteHelper.deleteObjectsIgnoreNotExists(clientReference.get(), blobStore.bucket(), blobNames, outstanding);
+            }
         } catch (Exception e) {
             throw new IOException("Failed to delete blobs [" + outstanding + "]", e);
         }
@@ -529,7 +529,11 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
             }
             String prefix = blobNamePrefix == null ? keyPath : buildKey(blobNamePrefix);
             try (AmazonS3Reference clientReference = blobStore.clientReference()) {
-                List<BlobMetadata> blobs = executeListing(clientReference, listObjectsRequest(prefix, limit, clientReference.isFullyS3Compatible()), limit).stream()
+                List<BlobMetadata> blobs = executeListing(
+                    clientReference,
+                    listObjectsRequest(prefix, limit, clientReference.isFullyS3Compatible()),
+                    limit
+                ).stream()
                     .flatMap(listing -> listing.contents().stream())
                     .map(s3Object -> new PlainBlobMetadata(s3Object.key().substring(keyPath.length()), s3Object.size()))
                     .collect(Collectors.toList());
@@ -561,17 +565,18 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
     @Override
     public Map<String, BlobContainer> children() throws IOException {
         try (AmazonS3Reference clientReference = blobStore.clientReference()) {
-            return executeListing(clientReference, listObjectsRequest(keyPath, clientReference.isFullyS3Compatible())).stream().flatMap(listObjectsResponse -> {
-                assert listObjectsResponse.contents().stream().noneMatch(s -> {
-                    for (CommonPrefix commonPrefix : listObjectsResponse.commonPrefixes()) {
-                        if (s.key().substring(keyPath.length()).startsWith(commonPrefix.prefix())) {
-                            return true;
+            return executeListing(clientReference, listObjectsRequest(keyPath, clientReference.isFullyS3Compatible())).stream()
+                .flatMap(listObjectsResponse -> {
+                    assert listObjectsResponse.contents().stream().noneMatch(s -> {
+                        for (CommonPrefix commonPrefix : listObjectsResponse.commonPrefixes()) {
+                            if (s.key().substring(keyPath.length()).startsWith(commonPrefix.prefix())) {
+                                return true;
+                            }
                         }
-                    }
-                    return false;
-                }) : "Response contained children for listed common prefixes.";
-                return listObjectsResponse.commonPrefixes().stream();
-            })
+                        return false;
+                    }) : "Response contained children for listed common prefixes.";
+                    return listObjectsResponse.commonPrefixes().stream();
+                })
                 .map(commonPrefix -> commonPrefix.prefix().substring(keyPath.length()))
                 .filter(name -> name.isEmpty() == false)
                 // Stripping the trailing slash off of the common prefix
@@ -612,7 +617,9 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
             .prefix(keyPath)
             .delimiter("/");
         if (isFullyS3Compatible) {
-            listObjectsV2RequestBuilder.overrideConfiguration(o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().listObjectsMetricPublisher));
+            listObjectsV2RequestBuilder.overrideConfiguration(
+                o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().listObjectsMetricPublisher)
+            );
         }
         return listObjectsV2RequestBuilder.build();
     }
@@ -660,8 +667,7 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
         try (AmazonS3Reference clientReference = blobStore.clientReference()) {
 
             if (clientReference.isFullyS3Compatible()) {
-                putObjectRequestBuilder
-                    .acl(blobStore.getCannedACL())
+                putObjectRequestBuilder.acl(blobStore.getCannedACL())
                     .overrideConfiguration(o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().putObjectMetricPublisher));
             }
             PutObjectRequest putObjectRequest = putObjectRequestBuilder.build();
@@ -730,8 +736,7 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
         try (AmazonS3Reference clientReference = blobStore.clientReference()) {
 
             if (clientReference.isFullyS3Compatible()) {
-                createMultipartUploadRequestBuilder
-                    .acl(blobStore.getCannedACL())
+                createMultipartUploadRequestBuilder.acl(blobStore.getCannedACL())
                     .overrideConfiguration(o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().multipartUploadMetricCollector));
             }
             CreateMultipartUploadRequest createMultipartUploadRequest = createMultipartUploadRequestBuilder.build();
@@ -748,14 +753,15 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
             long bytesCount = 0;
             for (int i = 1; i <= nbParts; i++) {
                 UploadPartRequest.Builder uploadPartRequestBuilder = UploadPartRequest.builder()
-                        .bucket(bucketName)
-                        .key(blobName)
-                        .uploadId(uploadId.get())
-                        .partNumber(i)
-                        .contentLength((i < nbParts) ? partSize : lastPartSize);
+                    .bucket(bucketName)
+                    .key(blobName)
+                    .uploadId(uploadId.get())
+                    .partNumber(i)
+                    .contentLength((i < nbParts) ? partSize : lastPartSize);
                 if (clientReference.isFullyS3Compatible()) {
-                    uploadPartRequestBuilder
-                        .overrideConfiguration(o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().multipartUploadMetricCollector));
+                    uploadPartRequestBuilder.overrideConfiguration(
+                        o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().multipartUploadMetricCollector)
+                    );
                 }
                 final UploadPartRequest uploadPartRequest = uploadPartRequestBuilder.build();
 
@@ -779,8 +785,9 @@ class S3BlobContainer extends AbstractBlobContainer implements AsyncMultiStreamB
                 .uploadId(uploadId.get())
                 .multipartUpload(CompletedMultipartUpload.builder().parts(parts).build());
             if (clientReference.isFullyS3Compatible()) {
-                multipartUploadRequestBuilder
-                    .overrideConfiguration(o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().multipartUploadMetricCollector));
+                multipartUploadRequestBuilder.overrideConfiguration(
+                    o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().multipartUploadMetricCollector)
+                );
             }
 
             CompleteMultipartUploadRequest completeMultipartUploadRequest = multipartUploadRequestBuilder.build();

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3BlobStore.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3BlobStore.java
@@ -102,6 +102,8 @@ public class S3BlobStore implements BlobStore {
     private final SizeBasedBlockingQ lowPrioritySizeBasedBlockingQ;
     private final GenericStatsMetricPublisher genericStatsMetricPublisher;
 
+    private boolean isFullyS3Compatible = true;
+
     S3BlobStore(
         S3Service service,
         S3AsyncService s3AsyncService,
@@ -145,6 +147,7 @@ public class S3BlobStore implements BlobStore {
 
         try (AmazonS3Reference clientReference = clientReference()) {
             if (clientReference != null) {
+                isFullyS3Compatible = clientReference.fullyS3Compatible;
                 asyncTransferManager.setFullyS3Compatible(clientReference.isFullyS3Compatible());
             }
         }
@@ -167,6 +170,10 @@ public class S3BlobStore implements BlobStore {
     @Override
     public String toString() {
         return bucket;
+    }
+
+    public boolean isFullyS3Compatible() {
+        return isFullyS3Compatible;
     }
 
     public AmazonS3Reference clientReference() {

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3BlobStore.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3BlobStore.java
@@ -142,6 +142,12 @@ public class S3BlobStore implements BlobStore {
         this.lowPrioritySizeBasedBlockingQ = lowPrioritySizeBasedBlockingQ;
         this.genericStatsMetricPublisher = genericStatsMetricPublisher;
         this.permitBackedTransferEnabled = PERMIT_BACKED_TRANSFER_ENABLED.get(repositoryMetadata.settings());
+
+        try (AmazonS3Reference clientReference = clientReference()) {
+            if (clientReference != null) {
+                asyncTransferManager.setFullyS3Compatible(clientReference.isFullyS3Compatible());
+            }
+        }
     }
 
     @Override

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3RetryingInputStream.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3RetryingInputStream.java
@@ -105,8 +105,10 @@ class S3RetryingInputStream extends InputStream {
         try (AmazonS3Reference clientReference = blobStore.clientReference()) {
             final GetObjectRequest.Builder getObjectRequest = GetObjectRequest.builder()
                 .bucket(blobStore.bucket())
-                .key(blobKey)
-                .overrideConfiguration(o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().getObjectMetricPublisher));
+                .key(blobKey);
+            if (clientReference.isFullyS3Compatible()) {
+                getObjectRequest.overrideConfiguration(o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().getObjectMetricPublisher));
+            }
             if (currentOffset > 0 || start > 0 || end < Long.MAX_VALUE - 1) {
                 assert start + currentOffset <= end : "requesting beyond end, start = "
                     + start

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3RetryingInputStream.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3RetryingInputStream.java
@@ -103,11 +103,11 @@ class S3RetryingInputStream extends InputStream {
 
     private void openStream() throws IOException {
         try (AmazonS3Reference clientReference = blobStore.clientReference()) {
-            final GetObjectRequest.Builder getObjectRequest = GetObjectRequest.builder()
-                .bucket(blobStore.bucket())
-                .key(blobKey);
+            final GetObjectRequest.Builder getObjectRequest = GetObjectRequest.builder().bucket(blobStore.bucket()).key(blobKey);
             if (clientReference.isFullyS3Compatible()) {
-                getObjectRequest.overrideConfiguration(o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().getObjectMetricPublisher));
+                getObjectRequest.overrideConfiguration(
+                    o -> o.addMetricPublisher(blobStore.getStatsMetricPublisher().getObjectMetricPublisher)
+                );
             }
             if (currentOffset > 0 || start > 0 || end < Long.MAX_VALUE - 1) {
                 assert start + currentOffset <= end : "requesting beyond end, start = "

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3Service.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3Service.java
@@ -156,6 +156,12 @@ class S3Service implements Closeable {
                 return existing;
             }
             final AmazonS3Reference clientReference = new AmazonS3Reference(buildClient(clientSettings));
+            String endpoint = clientSettings.endpoint;
+            if (endpoint != null) {
+                if (endpoint.toLowerCase().contains("storage.googleapis.com")) {
+                    clientReference.setFullyS3Compatible(false);
+                }
+            }
             clientReference.incRef();
             clientsCache = MapBuilder.newMapBuilder(clientsCache).put(clientSettings, clientReference).immutableMap();
             return clientReference;

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3Service.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3Service.java
@@ -158,7 +158,7 @@ class S3Service implements Closeable {
             final AmazonS3Reference clientReference = new AmazonS3Reference(buildClient(clientSettings));
             String endpoint = clientSettings.endpoint;
             if (endpoint != null) {
-                if (endpoint.toLowerCase().contains("storage.googleapis.com")) {
+                if (endpoint.contains("storage.googleapis.com")) {
                     clientReference.setFullyS3Compatible(false);
                 }
             }

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3Service.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/S3Service.java
@@ -58,6 +58,7 @@ import software.amazon.awssdk.services.sts.StsClientBuilder;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
 import software.amazon.awssdk.services.sts.auth.StsWebIdentityTokenFileCredentialsProvider;
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+import software.amazon.awssdk.utils.AttributeMap;
 
 import org.apache.http.conn.ssl.DefaultHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
@@ -73,7 +74,6 @@ import org.opensearch.core.common.Strings;
 import org.opensearch.repositories.s3.S3ClientSettings.IrsaCredentials;
 import org.opensearch.repositories.s3.utils.AwsRequestSigner;
 import org.opensearch.repositories.s3.utils.Protocol;
-import software.amazon.awssdk.utils.AttributeMap;
 
 import javax.net.ssl.SSLContext;
 

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/async/AsyncPartsHandler.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/async/AsyncPartsHandler.java
@@ -97,7 +97,9 @@ public class AsyncPartsHandler {
                     .uploadId(uploadId)
                     .contentLength(inputStreamContainer.getContentLength());
                 if (isFullyS3Compatible) {
-                    uploadPartRequestBuilder.overrideConfiguration(o -> o.addMetricPublisher(statsMetricPublisher.multipartUploadMetricCollector));
+                    uploadPartRequestBuilder.overrideConfiguration(
+                        o -> o.addMetricPublisher(statsMetricPublisher.multipartUploadMetricCollector)
+                    );
                 }
                 if (uploadRequest.doRemoteDataIntegrityCheck()) {
                     uploadPartRequestBuilder.checksumAlgorithm(ChecksumAlgorithm.CRC32);

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/async/AsyncPartsHandler.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/async/AsyncPartsHandler.java
@@ -75,7 +75,8 @@ public class AsyncPartsHandler {
         StatsMetricPublisher statsMetricPublisher,
         boolean uploadRetryEnabled,
         TransferSemaphoresHolder transferSemaphoresHolder,
-        long maxRetryablePartSize
+        long maxRetryablePartSize,
+        boolean isFullyS3Compatible
     ) throws InterruptedException {
         List<CompletableFuture<CompletedPart>> futures = new ArrayList<>();
         TransferSemaphoresHolder.RequestContext requestContext = transferSemaphoresHolder.createRequestContext();
@@ -94,8 +95,10 @@ public class AsyncPartsHandler {
                     .partNumber(partIdx + 1)
                     .key(uploadRequest.getKey())
                     .uploadId(uploadId)
-                    .overrideConfiguration(o -> o.addMetricPublisher(statsMetricPublisher.multipartUploadMetricCollector))
                     .contentLength(inputStreamContainer.getContentLength());
+                if (isFullyS3Compatible) {
+                    uploadPartRequestBuilder.overrideConfiguration(o -> o.addMetricPublisher(statsMetricPublisher.multipartUploadMetricCollector));
+                }
                 if (uploadRequest.doRemoteDataIntegrityCheck()) {
                     uploadPartRequestBuilder.checksumAlgorithm(ChecksumAlgorithm.CRC32);
                 }

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/async/AsyncTransferManager.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/async/AsyncTransferManager.java
@@ -67,6 +67,7 @@ public final class AsyncTransferManager {
     private final ExecutorService urgentExecutorService;
     private final long minimumPartSize;
     private final long maxRetryablePartSize;
+    private boolean fullyS3Compatible = true;
 
     @SuppressWarnings("rawtypes")
     private final TransferSemaphoresHolder transferSemaphoresHolder;
@@ -96,6 +97,14 @@ public final class AsyncTransferManager {
         this.maxRetryablePartSize = (long) (minimumPartSize + 0.1 * minimumPartSize);
         this.urgentExecutorService = urgentExecutorService;
         this.transferSemaphoresHolder = transferSemaphoresHolder;
+    }
+
+    public void setFullyS3Compatible(boolean fullyS3Compatible) {
+        this.fullyS3Compatible = fullyS3Compatible;
+    }
+
+    public boolean isFullyS3Compatible() {
+        return fullyS3Compatible;
     }
 
     /**
@@ -153,8 +162,11 @@ public final class AsyncTransferManager {
 
         CreateMultipartUploadRequest.Builder createMultipartUploadRequestBuilder = CreateMultipartUploadRequest.builder()
             .bucket(uploadRequest.getBucket())
-            .key(uploadRequest.getKey())
-            .overrideConfiguration(o -> o.addMetricPublisher(statsMetricPublisher.multipartUploadMetricCollector));
+            .key(uploadRequest.getKey());
+        if (isFullyS3Compatible()) {
+            createMultipartUploadRequestBuilder
+                .overrideConfiguration(o -> o.addMetricPublisher(statsMetricPublisher.multipartUploadMetricCollector));
+        }
 
         if (CollectionUtils.isNotEmpty(uploadRequest.getMetadata())) {
             createMultipartUploadRequestBuilder.metadata(uploadRequest.getMetadata());
@@ -212,7 +224,8 @@ public final class AsyncTransferManager {
                 statsMetricPublisher,
                 uploadRequest.isUploadRetryEnabled(),
                 transferSemaphoresHolder,
-                maxRetryablePartSize
+                maxRetryablePartSize,
+                fullyS3Compatible
             );
         } catch (Exception ex) {
             try {
@@ -289,14 +302,17 @@ public final class AsyncTransferManager {
 
         log.debug(() -> new ParameterizedMessage("Sending completeMultipartUploadRequest, uploadId: {}", uploadId));
         CompletedPart[] parts = IntStream.range(0, completedParts.length()).mapToObj(completedParts::get).toArray(CompletedPart[]::new);
-        CompleteMultipartUploadRequest completeMultipartUploadRequest = CompleteMultipartUploadRequest.builder()
+        CompleteMultipartUploadRequest.Builder completeMultipartUploadRequestBuilder = CompleteMultipartUploadRequest.builder()
             .bucket(uploadRequest.getBucket())
             .key(uploadRequest.getKey())
             .uploadId(uploadId)
-            .overrideConfiguration(o -> o.addMetricPublisher(statsMetricPublisher.multipartUploadMetricCollector))
-            .multipartUpload(CompletedMultipartUpload.builder().parts(parts).build())
-            .build();
+            .multipartUpload(CompletedMultipartUpload.builder().parts(parts).build());
 
+        if (fullyS3Compatible) {
+            completeMultipartUploadRequestBuilder
+                .overrideConfiguration(o -> o.addMetricPublisher(statsMetricPublisher.multipartUploadMetricCollector));
+        }
+        CompleteMultipartUploadRequest completeMultipartUploadRequest = completeMultipartUploadRequestBuilder.build();
         return SocketAccess.doPrivileged(() -> s3AsyncClient.completeMultipartUpload(completeMultipartUploadRequest));
     }
 
@@ -355,8 +371,12 @@ public final class AsyncTransferManager {
         PutObjectRequest.Builder putObjectRequestBuilder = PutObjectRequest.builder()
             .bucket(uploadRequest.getBucket())
             .key(uploadRequest.getKey())
-            .contentLength(uploadRequest.getContentLength())
-            .overrideConfiguration(o -> o.addMetricPublisher(statsMetricPublisher.putObjectMetricPublisher));
+            .contentLength(uploadRequest.getContentLength());
+
+        if (fullyS3Compatible) {
+            putObjectRequestBuilder
+                .overrideConfiguration(o -> o.addMetricPublisher(statsMetricPublisher.putObjectMetricPublisher));
+        }
 
         if (CollectionUtils.isNotEmpty(uploadRequest.getMetadata())) {
             putObjectRequestBuilder.metadata(uploadRequest.getMetadata());

--- a/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/async/AsyncTransferManager.java
+++ b/plugins/repository-s3/src/main/java/org/opensearch/repositories/s3/async/AsyncTransferManager.java
@@ -164,8 +164,9 @@ public final class AsyncTransferManager {
             .bucket(uploadRequest.getBucket())
             .key(uploadRequest.getKey());
         if (isFullyS3Compatible()) {
-            createMultipartUploadRequestBuilder
-                .overrideConfiguration(o -> o.addMetricPublisher(statsMetricPublisher.multipartUploadMetricCollector));
+            createMultipartUploadRequestBuilder.overrideConfiguration(
+                o -> o.addMetricPublisher(statsMetricPublisher.multipartUploadMetricCollector)
+            );
         }
 
         if (CollectionUtils.isNotEmpty(uploadRequest.getMetadata())) {
@@ -309,8 +310,9 @@ public final class AsyncTransferManager {
             .multipartUpload(CompletedMultipartUpload.builder().parts(parts).build());
 
         if (fullyS3Compatible) {
-            completeMultipartUploadRequestBuilder
-                .overrideConfiguration(o -> o.addMetricPublisher(statsMetricPublisher.multipartUploadMetricCollector));
+            completeMultipartUploadRequestBuilder.overrideConfiguration(
+                o -> o.addMetricPublisher(statsMetricPublisher.multipartUploadMetricCollector)
+            );
         }
         CompleteMultipartUploadRequest completeMultipartUploadRequest = completeMultipartUploadRequestBuilder.build();
         return SocketAccess.doPrivileged(() -> s3AsyncClient.completeMultipartUpload(completeMultipartUploadRequest));
@@ -374,8 +376,7 @@ public final class AsyncTransferManager {
             .contentLength(uploadRequest.getContentLength());
 
         if (fullyS3Compatible) {
-            putObjectRequestBuilder
-                .overrideConfiguration(o -> o.addMetricPublisher(statsMetricPublisher.putObjectMetricPublisher));
+            putObjectRequestBuilder.overrideConfiguration(o -> o.addMetricPublisher(statsMetricPublisher.putObjectMetricPublisher));
         }
 
         if (CollectionUtils.isNotEmpty(uploadRequest.getMetadata())) {


### PR DESCRIPTION
Support repository and snapshot with Google GCS using S3 repository plugin. The existing repository-s3 use some configuration on client and requests that are not supported by GCS. Also workaround the limitation in GCS where bulk delete is not supported.